### PR TITLE
Fix Swift 2 selectors and allow subclassing.

### DIFF
--- a/MediumMenu-Sample/MediumMenu-Sample/BaseViewController.swift
+++ b/MediumMenu-Sample/MediumMenu-Sample/BaseViewController.swift
@@ -12,7 +12,7 @@ class BaseViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let icon = UIBarButtonItem(image: UIImage(named: "medium_icon"), style: .Plain, target: navigationController, action: "showMenu")
+        let icon = UIBarButtonItem(image: UIImage(named: "medium_icon"), style: .Plain, target: navigationController, action: Selector("showMenu"))
         icon.imageInsets = UIEdgeInsetsMake(-10, 0, 0, 0)
         icon.tintColor = UIColor.blackColor()
         navigationItem.leftBarButtonItem = icon

--- a/MediumMenu/MediumMenu.swift
+++ b/MediumMenu/MediumMenu.swift
@@ -34,7 +34,7 @@ public class MediumMenu: UIView {
     private let cellIdentifier = "cell"
     private var currentState: State = .Closed
     private var contentController: UIViewController?
-    private var menuContentTableView: UITableView?
+    internal var menuContentTableView: UITableView?
 
     public var panGestureEnable: Bool = true
     public var titleAlignment: Alignment = .Left

--- a/MediumMenu/MediumMenu.swift
+++ b/MediumMenu/MediumMenu.swift
@@ -83,7 +83,7 @@ public class MediumMenu: UIView {
         super.init(coder: aDecoder)
     }
     
-    public convenience init(items: [MediumMenuItem], forViewController: UIViewController) {
+    public init(items: [MediumMenuItem], forViewController: UIViewController) {
         self.init()
         self.items = items
         height = CGRectGetHeight(UIScreen.mainScreen().bounds)-80 // auto-calculate initial height based on screen size
@@ -98,7 +98,7 @@ public class MediumMenu: UIView {
         addSubview(menuContentTableView!)
         
         if panGestureEnable {
-            let pan = UIPanGestureRecognizer(target: self, action: "didPan:")
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(MediumMenu.didPan(_:)))
             contentController?.view.addGestureRecognizer(pan)
         }
 

--- a/MediumMenu/MediumMenu.swift
+++ b/MediumMenu/MediumMenu.swift
@@ -34,7 +34,7 @@ public class MediumMenu: UIView {
     private let cellIdentifier = "cell"
     private var currentState: State = .Closed
     private var contentController: UIViewController?
-    internal var menuContentTableView: UITableView?
+    public var menuContentTableView: UITableView?
 
     public var panGestureEnable: Bool = true
     public var titleAlignment: Alignment = .Left


### PR DESCRIPTION
Hey!

While developing one of my apps, I needed the ability to directly modify the location and general look of the menu, preferably from a subclass so all changes were centralized.

In order to enable that, i've made the main init a secondary public initializer, and made the tableview access public. This minor change shouldn't break anything and appears to be backwards compatible with everything i've tested, as well as allowing this functionality. 

Thanks!
Jon