### PR TITLE
adds contentController as root and inserts menu subview behind it

### DIFF
--- a/MediumMenu/MediumMenu.swift
+++ b/MediumMenu/MediumMenu.swift
@@ -117,8 +117,9 @@ public class MediumMenu: UIView {
 
         let menuController = UIViewController()
         menuController.view = self
-        UIApplication.sharedApplication().delegate?.window??.rootViewController = menuController
-        UIApplication.sharedApplication().delegate?.window??.addSubview(contentController!.view)
+        
+        UIApplication.sharedApplication().delegate?.window??.rootViewController = contentController
+        UIApplication.sharedApplication().delegate?.window??.insertSubview(menuController.view, atIndex: 0)
     }
     
     public override func layoutSubviews() {


### PR DESCRIPTION
This fixes 2 issues.  

1.  When launching any modal I was getting a warning "Warning :-Presenting view controllers on detached view controllers is discouraged".  

2.  UI issue with pop behavior with the navigation controller.  If you pushed to another view and then pop back to it, the navigation bar was animating but the view itself was not.  

Both of these issues are resolved with this PR.